### PR TITLE
Add typed metric tables and display latest values

### DIFF
--- a/src/backend/jobs/cpu.rs
+++ b/src/backend/jobs/cpu.rs
@@ -1,8 +1,8 @@
 use super::job::JobResult;
 use anyhow::Result;
-use serde::Serialize;
+use serde::{Serialize, Deserialize};
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct CpuInfo {
     pub model_name: String,
     pub core_count: usize,

--- a/src/backend/jobs/disk.rs
+++ b/src/backend/jobs/disk.rs
@@ -1,8 +1,8 @@
 use super::job::JobResult;
 use anyhow::Result;
-use serde::Serialize;
+use serde::{Serialize, Deserialize};
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct DiskInfo {
     pub mount_point: String,
     pub total_mb: u64,

--- a/src/backend/jobs/mem.rs
+++ b/src/backend/jobs/mem.rs
@@ -1,8 +1,8 @@
 use super::job::JobResult;
 use anyhow::{Result, anyhow};
-use serde::Serialize;
+use serde::{Serialize, Deserialize};
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct MemInfo {
     pub total_mb: u64,
     pub used_mb: u64,

--- a/src/tui/list_ssh/mod.rs
+++ b/src/tui/list_ssh/mod.rs
@@ -2,6 +2,7 @@ pub mod themed_table;
 pub mod update;
 pub mod view;
 pub mod view_table_row;
+pub mod states;
 
 pub use update::handle_key;
 pub use view::render;

--- a/src/tui/list_ssh/states.rs
+++ b/src/tui/list_ssh/states.rs
@@ -1,0 +1,61 @@
+use std::collections::HashMap;
+use rusqlite::Connection;
+
+use crate::backend::db::{latest_cpu, latest_disks, latest_mem};
+use crate::backend::jobs::{cpu::CpuInfo, mem::MemInfo, disk::DiskInfo};
+use crate::ssh_config::SshHostInfo;
+
+#[derive(Debug, Clone)]
+pub struct DiskOverview {
+    pub total_mb: u64,
+    pub used_mb: u64,
+    pub used_percent: f32,
+}
+
+#[derive(Debug, Clone)]
+pub struct HostMetrics {
+    pub cpu: Option<CpuInfo>,
+    pub mem: Option<MemInfo>,
+    pub disk: Option<DiskOverview>,
+}
+
+#[derive(Default, Debug)]
+pub struct ListStates {
+    pub metrics: HashMap<String, HostMetrics>,
+}
+
+impl ListStates {
+    pub fn refresh(&mut self, conn: &Connection, hosts: &[(String, SshHostInfo)]) {
+        for (id, _info) in hosts {
+            let cpu = latest_cpu(conn, id).ok().flatten();
+            let mem = latest_mem(conn, id).ok().flatten();
+            let disks = latest_disks(conn, id).ok().unwrap_or_default();
+            let disk = summarize_disks(&disks);
+            self.metrics.insert(
+                id.clone(),
+                HostMetrics { cpu, mem, disk },
+            );
+        }
+    }
+
+    pub fn get(&self, id: &str) -> Option<&HostMetrics> {
+        self.metrics.get(id)
+    }
+}
+
+fn summarize_disks(disks: &[DiskInfo]) -> Option<DiskOverview> {
+    if disks.is_empty() {
+        return None;
+    }
+    let total: u64 = disks.iter().map(|d| d.total_mb).sum();
+    let used: u64 = disks.iter().map(|d| d.used_mb).sum();
+    if total == 0 {
+        return None;
+    }
+    let used_percent = used as f32 / total as f32 * 100.0;
+    Some(DiskOverview {
+        total_mb: total,
+        used_mb: used,
+        used_percent,
+    })
+}

--- a/src/tui/list_ssh/view_table_row.rs
+++ b/src/tui/list_ssh/view_table_row.rs
@@ -1,10 +1,18 @@
 use super::themed_table::TableColors;
+use crate::backend::jobs::{cpu::CpuInfo, disk::DiskInfo, mem::MemInfo};
 use crate::ssh_config::SshHostInfo;
 use ratatui::prelude::*;
 use ratatui::widgets::*;
 
 #[allow(clippy::too_many_arguments)]
-pub fn render(i: usize, info: &SshHostInfo, colors: &TableColors) -> Row<'static> {
+pub fn render(
+    i: usize,
+    info: &SshHostInfo,
+    cpu: Option<&CpuInfo>,
+    mem: Option<&MemInfo>,
+    disk: Option<&DiskInfo>,
+    colors: &TableColors,
+) -> Row<'static> {
     let bg = if i % 2 == 0 {
         colors.normal_row_color
     } else {
@@ -13,9 +21,22 @@ pub fn render(i: usize, info: &SshHostInfo, colors: &TableColors) -> Row<'static
 
     let user_at_host = format!("{}@{}:{}", info.user, info.ip, info.port);
 
+    let cpu_cell = cpu
+        .map(|c| format!("{:.1}%", c.usage_percent))
+        .unwrap_or_else(|| "-".into());
+    let mem_cell = mem
+        .map(|m| format!("{:.1}%", m.used_percent))
+        .unwrap_or_else(|| "-".into());
+    let disk_cell = disk
+        .map(|d| format!("{:.1}%", d.used_percent))
+        .unwrap_or_else(|| "-".into());
+
     Row::new(vec![
         Cell::from(info.name.clone()),
         Cell::from(user_at_host),
+        Cell::from(cpu_cell),
+        Cell::from(mem_cell),
+        Cell::from(disk_cell),
     ])
     .style(Style::default().bg(bg))
     .height(2)

--- a/src/tui/list_ssh/view_table_row.rs
+++ b/src/tui/list_ssh/view_table_row.rs
@@ -1,5 +1,6 @@
 use super::themed_table::TableColors;
-use crate::backend::jobs::{cpu::CpuInfo, disk::DiskInfo, mem::MemInfo};
+use crate::backend::jobs::{cpu::CpuInfo, mem::MemInfo};
+use super::states::DiskOverview;
 use crate::ssh_config::SshHostInfo;
 use ratatui::prelude::*;
 use ratatui::widgets::*;
@@ -10,7 +11,7 @@ pub fn render(
     info: &SshHostInfo,
     cpu: Option<&CpuInfo>,
     mem: Option<&MemInfo>,
-    disk: Option<&DiskInfo>,
+    disk: Option<&DiskOverview>,
     colors: &TableColors,
 ) -> Row<'static> {
     let bg = if i % 2 == 0 {


### PR DESCRIPTION
## Summary
- add CPU/memory/disk metric tables to the database
- store metrics into new tables and keep old JSON table
- read latest metrics when rendering host list and show CPU/Mem/Disk usage

## Testing
- `cargo test --quiet` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_6871f24e63108321bda1daff6bc62084