### PR TITLE
Add cpu usage state to list_ssh module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,6 +89,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
+name = "async-trait"
+version = "0.1.88"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1288,6 +1299,7 @@ name = "ssh-monitor"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "color-eyre",
  "crossterm",
  "directories",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2024"
 
 [dependencies]
 anyhow = "1.0.98"
+async-trait = "0.1.88"
 color-eyre = "0.6.3"
 crossterm = { version = "0.28.1", features = ["event-stream"] }
 directories = "6.0.0"

--- a/src/backend/db/cpu/mod.rs
+++ b/src/backend/db/cpu/mod.rs
@@ -1,1 +1,2 @@
 pub mod commands;
+pub mod queries;

--- a/src/backend/db/cpu/queries.rs
+++ b/src/backend/db/cpu/queries.rs
@@ -1,0 +1,33 @@
+use anyhow::Result;
+use rusqlite::Connection;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+#[derive(Debug, Clone)]
+pub struct CpuResultRow {
+    pub host_id: String,
+    pub core_count: u32,
+    pub usage_percent: f32,
+}
+
+pub async fn fetch_latest_cpu_all(conn: &Arc<Mutex<Connection>>) -> Result<Vec<CpuResultRow>> {
+    let conn = conn.lock().await;
+    let mut stmt = conn.prepare(
+        "SELECT c.host_id, c.core_count, c.usage_percent \
+         FROM cpu_results c \
+         JOIN (SELECT host_id, MAX(timestamp) AS max_ts FROM cpu_results GROUP BY host_id) t \
+           ON c.host_id = t.host_id AND c.timestamp = t.max_ts",
+    )?;
+    let rows = stmt.query_map([], |row| {
+        Ok(CpuResultRow {
+            host_id: row.get::<_, String>(0)?,
+            core_count: row.get::<_, i64>(1)? as u32,
+            usage_percent: row.get::<_, f64>(2)? as f32,
+        })
+    })?;
+    let mut results = vec![];
+    for r in rows {
+        results.push(r?);
+    }
+    Ok(results)
+}

--- a/src/backend/jobs/cpu.rs
+++ b/src/backend/jobs/cpu.rs
@@ -58,11 +58,9 @@ pub fn parse_cpu(output: &str) -> Result<Option<JobResult>> {
 
     let (usage_percent, per_core) = if is_mac {
         let mut sum = 0f32;
-        let mut count = 0;
         for line in stat_part.lines() {
             if let Ok(p) = line.trim().parse::<f32>() {
                 sum += p;
-                count += 1;
             }
         }
         (sum, vec![])

--- a/src/backend/jobs/executor.rs
+++ b/src/backend/jobs/executor.rs
@@ -9,7 +9,7 @@ use tokio::{
     task, time,
 };
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct JobGroupExecutor {
     groups: Arc<RwLock<HashMap<String, JobGroup>>>,
     db: Arc<Mutex<Connection>>,
@@ -56,7 +56,7 @@ async fn run_group_task(group: JobGroup, conn: Arc<Mutex<Connection>>) {
                     // Find the corresponding JobKind for this result
                     if let Some(job_kind) = group.jobs.iter().find(|j| j.name() == result.job_name)
                     {
-                        if let Err(e) = job_kind.save(&conn, &group.host.name, &result).await {
+                        if let Err(e) = job_kind.save(&conn, &group.host.id, &result).await {
                             error!("❌ Failed to save {} result to DB: {e}", result.job_name);
                         }
                     } else {

--- a/src/backend/jobs/job.rs
+++ b/src/backend/jobs/job.rs
@@ -14,7 +14,7 @@ pub struct JobResult {
     pub value: Box<dyn Any + Send + Sync>,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub enum JobKind {
     Cpu,
     Mem,
@@ -94,11 +94,11 @@ impl JobKind {
             }
             JobKind::Disk => {
                 use crate::backend::db::disk::commands::{DiskResultInsert, store_disk_result};
-                use crate::backend::jobs::disk::DiskInfo; // 👈 You must match this path exactly
+                use crate::backend::jobs::disk::DiskInfo;
 
                 let disk_infos = result
                     .value
-                    .downcast_ref::<Vec<DiskInfo>>() // 👈 Make sure it's the exact type as Boxed above
+                    .downcast_ref::<Vec<DiskInfo>>()
                     .ok_or_else(|| anyhow::anyhow!("Expected Vec<DiskInfo> for JobKind::Disk"))?;
 
                 for info in disk_infos {
@@ -119,7 +119,7 @@ impl JobKind {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct JobGroup {
     pub name: String,
     pub interval: Duration,

--- a/src/ssh_config.rs
+++ b/src/ssh_config.rs
@@ -1,5 +1,4 @@
 use eyre::Result;
-use md5;
 use ssh2_config::{Host, ParseRule, SshConfig};
 use std::collections::HashMap;
 use std::sync::Arc;

--- a/src/tui/list_ssh/mod.rs
+++ b/src/tui/list_ssh/mod.rs
@@ -1,3 +1,4 @@
+pub mod states;
 pub mod themed_table;
 pub mod update;
 pub mod view;

--- a/src/tui/list_ssh/states.rs
+++ b/src/tui/list_ssh/states.rs
@@ -1,0 +1,85 @@
+use crate::backend::db::cpu::queries;
+use crate::tui::states_update::StateJob;
+use anyhow::Result;
+use rusqlite::Connection;
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::{Mutex, RwLock};
+
+/// Snapshot of CPU usage for a single host
+#[derive(Debug, Clone, Default)]
+pub struct CpuSnapshot {
+    pub core_count: u32,
+    pub usage_percent: f32,
+}
+
+/// Stores the latest CPU snapshots by host_id
+#[derive(Debug, Clone)]
+pub struct CpuStates {
+    data: Arc<RwLock<HashMap<String, CpuSnapshot>>>,
+}
+
+impl CpuStates {
+    pub fn new() -> Self {
+        Self {
+            data: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+
+    /// Get the latest snapshot for a given host, if present.
+    pub async fn get(&self, host_id: &str) -> Option<CpuSnapshot> {
+        self.data.read().await.get(host_id).cloned()
+    }
+
+    /// Fetch latest CPU rows from DB and update internal map
+    pub async fn update_from_db(&self, conn: &Arc<Mutex<Connection>>) -> Result<()> {
+        let rows = queries::fetch_latest_cpu_all(conn).await?;
+        log::info!("Fetched {} CPU rows from DB", rows.len());
+        let mut map = self.data.write().await;
+        map.clear();
+        for row in rows {
+            log::debug!(
+                "📥 Inserting CPU snapshot: host_id={}, core_count={}, usage_percent={}",
+                row.host_id,
+                row.core_count,
+                row.usage_percent
+            );
+            map.insert(
+                row.host_id,
+                CpuSnapshot {
+                    core_count: row.core_count,
+                    usage_percent: row.usage_percent,
+                },
+            );
+        }
+        Ok(())
+    }
+
+    pub async fn snapshot_map(&self) -> HashMap<String, CpuSnapshot> {
+        self.data.read().await.clone()
+    }
+}
+
+// ────────────────────────────
+// List View Job Kind Enum
+// ────────────────────────────
+
+#[derive(Clone, Debug)]
+pub enum ListSshJobKind {
+    Cpu(Arc<CpuStates>),
+}
+
+#[async_trait::async_trait]
+impl StateJob for ListSshJobKind {
+    fn name(&self) -> &'static str {
+        match self {
+            ListSshJobKind::Cpu(_) => "cpu",
+        }
+    }
+
+    async fn update(&self, conn: &Arc<Mutex<Connection>>) -> Result<()> {
+        match self {
+            ListSshJobKind::Cpu(state) => state.update_from_db(conn).await,
+        }
+    }
+}

--- a/src/tui/list_ssh/view_table_row.rs
+++ b/src/tui/list_ssh/view_table_row.rs
@@ -1,21 +1,36 @@
 use super::themed_table::TableColors;
 use crate::ssh_config::SshHostInfo;
+use crate::tui::list_ssh::states::CpuSnapshot;
 use ratatui::prelude::*;
 use ratatui::widgets::*;
 
-#[allow(clippy::too_many_arguments)]
-pub fn render(i: usize, info: &SshHostInfo, colors: &TableColors) -> Row<'static> {
+/// Render a single table row for a given SSH host and optional CPU snapshot.
+pub fn render(
+    i: usize,
+    info: &SshHostInfo,
+    colors: &TableColors,
+    cpu: &Option<CpuSnapshot>,
+) -> Row<'static> {
+    // Alternate row background
     let bg = if i % 2 == 0 {
         colors.normal_row_color
     } else {
         colors.alt_row_color
     };
 
+    // Format user@host:port
     let user_at_host = format!("{}@{}:{}", info.user, info.ip, info.port);
+
+    // Format CPU usage text
+    let cpu_text = cpu
+        .as_ref()
+        .map(|c| format!("{:.1}% / {}c", c.usage_percent, c.core_count))
+        .unwrap_or_else(|| "-".to_string());
 
     Row::new(vec![
         Cell::from(info.name.clone()),
         Cell::from(user_at_host),
+        Cell::from(cpu_text),
     ])
     .style(Style::default().bg(bg))
     .height(2)

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1,1 +1,50 @@
 pub mod list_ssh;
+pub mod states_update;
+
+#[tokio::test]
+async fn test_cpu_job_executor_runs() {
+    use super::tui::states_update::{StatesJobExecutor, StatesJobGroup};
+    use crate::backend::db::cpu::commands::{CpuResultInsert, store_cpu_result};
+    use crate::backend::db::init_db_connection;
+    use crate::tui::list_ssh::states::{CpuStates, ListSshJobKind};
+    use std::sync::Arc;
+    use std::time::Duration;
+    use tokio::sync::Mutex;
+
+    let db = Arc::new(Mutex::new(init_db_connection()));
+    let cpu_states = CpuStates::new();
+    let job = ListSshJobKind::Cpu(cpu_states.clone());
+
+    // Insert a fake CPU result for host_id = "test-host"
+    {
+        let insert = CpuResultInsert {
+            host_id: "test-host".to_string(),
+            model_name: "FakeCPU".to_string(),
+            core_count: 8,
+            usage_percent: 33.3,
+            per_core: vec![10.0, 20.0, 30.0, 40.0, 10.0, 20.0, 30.0, 40.0],
+        };
+        store_cpu_result(&db, &insert).await.unwrap();
+    }
+
+    let job_group = StatesJobGroup {
+        name: "list_view".into(),
+        interval: Duration::from_millis(100),
+        jobs: vec![job],
+    };
+
+    let executor = StatesJobExecutor::new(db.clone());
+    executor.register_group(job_group).await;
+    executor.run_all().await;
+
+    // Let it run long enough to trigger the update
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    // Assert CpuStates is updated
+    let snapshot = cpu_states.get("test-host").await;
+    assert!(snapshot.is_some());
+
+    let snapshot = snapshot.unwrap();
+    assert_eq!(snapshot.core_count, 8);
+    assert!((snapshot.usage_percent - 33.3).abs() < f32::EPSILON);
+}

--- a/src/tui/states_update.rs
+++ b/src/tui/states_update.rs
@@ -1,0 +1,79 @@
+use anyhow::Result;
+use rusqlite::Connection;
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::{Mutex, RwLock};
+use tokio::{task, time};
+
+#[async_trait::async_trait]
+pub trait StateJob: Send + Sync {
+    /// Name of the job (e.g. "cpu", "mem")
+    fn name(&self) -> &'static str;
+
+    /// Performs the update from DB or other source
+    async fn update(&self, db: &Arc<Mutex<Connection>>) -> Result<()>;
+}
+
+#[derive(Clone, Debug)]
+pub struct StatesJobGroup<T: StateJob> {
+    pub name: String,
+    pub interval: std::time::Duration,
+    pub jobs: Vec<T>,
+}
+
+#[derive(Debug)]
+pub struct StatesJobExecutor<T: StateJob> {
+    groups: Arc<RwLock<HashMap<String, StatesJobGroup<T>>>>,
+    db: Arc<Mutex<Connection>>,
+}
+
+impl<T: StateJob + 'static + Clone> StatesJobExecutor<T> {
+    pub fn new(db: Arc<Mutex<Connection>>) -> Self {
+        Self {
+            groups: Arc::new(RwLock::new(HashMap::new())),
+            db,
+        }
+    }
+
+    pub async fn register_group(&self, group: StatesJobGroup<T>) {
+        let mut groups = self.groups.write().await;
+        groups.insert(group.name.clone(), group);
+    }
+
+    pub async fn run_all(&self) {
+        let groups = self.groups.read().await;
+        for group in groups.values().cloned() {
+            let db = self.db.clone();
+            task::spawn(async move {
+                run_group_task(group, db).await;
+            });
+        }
+    }
+}
+
+async fn run_group_task<T: StateJob + 'static + Clone>(
+    group: StatesJobGroup<T>,
+    conn: Arc<Mutex<Connection>>,
+) {
+    loop {
+        if let Err(e) = run_group_once(&group, &conn).await {
+            log::error!("❌ Error running group '{}': {e}", group.name);
+        }
+        time::sleep(group.interval).await;
+    }
+}
+
+async fn run_group_once<T: StateJob + 'static + Clone>(
+    group: &StatesJobGroup<T>,
+    conn: &Arc<Mutex<Connection>>,
+) -> Result<()> {
+    log::info!("🚀 Running states job group '{}'", group.name);
+    for job in &group.jobs {
+        if let Err(e) = job.update(conn).await {
+            log::error!("❌ Failed to update '{}': {e}", job.name());
+        } else {
+            log::debug!("✅ Successfully updated '{}'", job.name());
+        }
+    }
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- move CPU states into the list_ssh module
- use CpuStates from list_ssh to update CPU data

## Testing
- `cargo test --quiet` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6873aca1eda883219007ce088cf1790b