### PR TITLE
Add GPU job support

### DIFF
--- a/src/backend/db/gpu/commands.rs
+++ b/src/backend/db/gpu/commands.rs
@@ -1,0 +1,43 @@
+use anyhow::Result;
+use rusqlite::{Connection, params};
+use serde::Serialize;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+#[derive(Serialize)]
+pub struct GpuResultInsert {
+    pub host_id: String,
+    pub gpu_index: u32,
+    pub name: String,
+    pub memory_total_mb: Option<u64>,
+    pub memory_used_mb: Option<u64>,
+    pub temperature_c: Option<f32>,
+    pub raw_output: Option<String>,
+}
+
+pub async fn store_gpu_result(conn: &Arc<Mutex<Connection>>, data: &GpuResultInsert) -> Result<()> {
+    let conn = conn.lock().await;
+    conn.execute(
+        r#"
+        INSERT INTO gpu_results (
+            host_id,
+            gpu_index,
+            name,
+            memory_total_mb,
+            memory_used_mb,
+            temperature_c,
+            raw_output
+        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+        "#,
+        params![
+            data.host_id,
+            data.gpu_index as i64,
+            data.name,
+            data.memory_total_mb.map(|v| v as i64),
+            data.memory_used_mb.map(|v| v as i64),
+            data.temperature_c,
+            data.raw_output,
+        ],
+    )?;
+    Ok(())
+}

--- a/src/backend/db/gpu/mod.rs
+++ b/src/backend/db/gpu/mod.rs
@@ -1,0 +1,2 @@
+pub mod commands;
+pub mod queries;

--- a/src/backend/db/gpu/queries.rs
+++ b/src/backend/db/gpu/queries.rs
@@ -1,0 +1,38 @@
+use anyhow::Result;
+use rusqlite::Connection;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+#[derive(Debug, Clone)]
+pub struct GpuResultRow {
+    pub host_id: String,
+    pub gpu_index: u32,
+    pub name: String,
+    pub memory_total_mb: Option<u64>,
+    pub memory_used_mb: Option<u64>,
+    pub temperature_c: Option<f32>,
+    pub raw_output: Option<String>,
+}
+
+pub async fn fetch_latest_gpu_all(conn: &Arc<Mutex<Connection>>) -> Result<Vec<GpuResultRow>> {
+    let conn = conn.lock().await;
+    let mut stmt = conn.prepare(
+        "SELECT g.host_id, g.gpu_index, g.name, g.memory_total_mb, g.memory_used_mb, g.temperature_c, g.raw_output \n         FROM gpu_results g \n         JOIN (SELECT host_id, gpu_index, MAX(timestamp) AS max_ts FROM gpu_results GROUP BY host_id, gpu_index) t \n           ON g.host_id = t.host_id AND g.gpu_index = t.gpu_index AND g.timestamp = t.max_ts",
+    )?;
+    let rows = stmt.query_map([], |row| {
+        Ok(GpuResultRow {
+            host_id: row.get::<_, String>(0)?,
+            gpu_index: row.get::<_, i64>(1)? as u32,
+            name: row.get::<_, String>(2)?,
+            memory_total_mb: row.get::<_, Option<i64>>(3)?.map(|v| v as u64),
+            memory_used_mb: row.get::<_, Option<i64>>(4)?.map(|v| v as u64),
+            temperature_c: row.get::<_, Option<f64>>(5)?.map(|v| v as f32),
+            raw_output: row.get::<_, Option<String>>(6)?,
+        })
+    })?;
+    let mut results = Vec::new();
+    for r in rows {
+        results.push(r?);
+    }
+    Ok(results)
+}

--- a/src/backend/jobs/executor.rs
+++ b/src/backend/jobs/executor.rs
@@ -161,6 +161,7 @@ async fn test_job_executor() {
     use crate::backend::jobs::cpu::CpuInfo;
     use crate::backend::jobs::disk::DiskInfo;
     use crate::backend::jobs::executor::JobGroupExecutor;
+    use crate::backend::jobs::gpu::GpuInfo;
     use crate::backend::jobs::job::{JobGroup, JobKind};
     use crate::backend::jobs::mem::MemInfo;
     use crate::ssh_config::SshHostInfo;
@@ -185,7 +186,7 @@ async fn test_job_executor() {
         name: "test".to_string(),
         interval: Duration::from_secs(60),
         host,
-        jobs: vec![JobKind::Cpu, JobKind::Mem, JobKind::Disk],
+        jobs: vec![JobKind::Cpu, JobKind::Mem, JobKind::Disk, JobKind::Gpu],
     };
 
     let executor = JobGroupExecutor::new(db_conn.clone());
@@ -213,6 +214,13 @@ async fn test_job_executor() {
             "disk" => {
                 if let Some(disk_info) = r.value.downcast_ref::<Vec<DiskInfo>>() {
                     println!("✅ {} => {:?}", r.job_name, disk_info);
+                } else {
+                    println!("✅ {} => (failed to downcast)", r.job_name);
+                }
+            }
+            "gpu" => {
+                if let Some(gpu_info) = r.value.downcast_ref::<Vec<GpuInfo>>() {
+                    println!("✅ {} => {:?}", r.job_name, gpu_info);
                 } else {
                     println!("✅ {} => (failed to downcast)", r.job_name);
                 }

--- a/src/backend/jobs/gpu.rs
+++ b/src/backend/jobs/gpu.rs
@@ -1,0 +1,86 @@
+use super::job::JobResult;
+use anyhow::Result;
+use serde::Serialize;
+
+pub const GPU_COMMAND: &str = r#"bash -c '
+if [[ "$(uname)" == "Darwin" ]]; then
+  system_profiler SPDisplaysDataType
+else
+  nvidia-smi --query-gpu=name,memory.total,memory.used,temperature.gpu --format=csv,noheader,nounits 2>&1
+fi
+'"#;
+
+#[derive(Debug, Serialize, Clone)]
+pub struct GpuInfo {
+    pub index: u32,
+    pub name: String,
+    pub memory_total_mb: Option<u64>,
+    pub memory_used_mb: Option<u64>,
+    pub temperature_c: Option<f32>,
+    pub raw_output: Option<String>,
+}
+
+pub fn parse_gpu(output: &str) -> Result<Option<JobResult>> {
+    let mut infos = Vec::new();
+    let lines: Vec<&str> = output.lines().collect();
+    let parse_as_csv = lines.iter().all(|l| l.contains(','));
+
+    if parse_as_csv {
+        for (idx, line) in lines.iter().enumerate() {
+            let parts: Vec<&str> = line.split(',').map(|p| p.trim()).collect();
+            if parts.len() >= 4 {
+                let name = parts[0].to_string();
+                let memory_total_mb = parts[1].parse::<u64>().ok();
+                let memory_used_mb = parts[2].parse::<u64>().ok();
+                let temperature_c = parts[3].parse::<f32>().ok();
+                infos.push(GpuInfo {
+                    index: idx as u32,
+                    name,
+                    memory_total_mb,
+                    memory_used_mb,
+                    temperature_c,
+                    raw_output: None,
+                });
+            }
+        }
+    } else {
+        // Try to parse macOS output
+        for (idx, line) in lines.iter().enumerate() {
+            if let Some(rest) = line.split_once("Chipset Model:") {
+                infos.push(GpuInfo {
+                    index: idx as u32,
+                    name: rest.1.trim().to_string(),
+                    memory_total_mb: None,
+                    memory_used_mb: None,
+                    temperature_c: None,
+                    raw_output: None,
+                });
+            }
+        }
+    }
+
+    Ok(Some(JobResult {
+        job_name: "gpu".into(),
+        value: Box::new(infos),
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_gpu() -> Result<()> {
+        let input = "GeForce GTX 1080 Ti, 11178, 4523, 70\nTesla K80, 11441, 0, 35";
+        let result = parse_gpu(input)?;
+        assert!(result.is_some());
+        let job_result = result.unwrap();
+        let infos: &Vec<GpuInfo> = job_result.value.downcast_ref::<Vec<GpuInfo>>().unwrap();
+        assert_eq!(infos.len(), 2);
+        assert_eq!(infos[0].name, "GeForce GTX 1080 Ti");
+        assert_eq!(infos[0].memory_total_mb, Some(11178));
+        assert_eq!(infos[0].memory_used_mb, Some(4523));
+        assert_eq!(infos[0].temperature_c, Some(70.0));
+        Ok(())
+    }
+}

--- a/src/backend/jobs/mod.rs
+++ b/src/backend/jobs/mod.rs
@@ -1,5 +1,6 @@
 pub mod cpu;
 pub mod disk;
 pub mod executor;
+pub mod gpu;
 pub mod job;
 pub mod mem;

--- a/src/main.rs
+++ b/src/main.rs
@@ -106,7 +106,7 @@ impl App {
                     name: host_id.clone(),
                     interval: std::time::Duration::from_secs(1),
                     host: host.clone(),
-                    jobs: vec![JobKind::Cpu, JobKind::Mem, JobKind::Disk],
+                    jobs: vec![JobKind::Cpu, JobKind::Mem, JobKind::Disk, JobKind::Gpu],
                 };
 
                 executor.register_group(group).await;
@@ -215,7 +215,7 @@ impl App {
                 name: host_id.clone(),
                 interval: std::time::Duration::from_secs(60),
                 host: host.clone(),
-                jobs: vec![JobKind::Cpu, JobKind::Mem, JobKind::Disk],
+                jobs: vec![JobKind::Cpu, JobKind::Mem, JobKind::Disk, JobKind::Gpu],
             };
 
             executor.register_group(group).await;


### PR DESCRIPTION
## Summary
- create gpu_results table and cleanup logic
- implement GPU job parser for Linux and macOS
- wire GPU job into job executor and job kind
- update main app and executor test to include GPU

## Testing
- `cargo test --quiet` *(fails: failed to download index.crates.io)*

------
https://chatgpt.com/codex/tasks/task_e_687a060d047c8321a4f999cd366ed474