### PR TITLE
Implement CPU detail view with per-core metrics

### DIFF
--- a/src/backend/db/cpu/queries.rs
+++ b/src/backend/db/cpu/queries.rs
@@ -1,31 +1,38 @@
 use anyhow::Result;
 use rusqlite::Connection;
+use serde_json;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
 #[derive(Debug, Clone)]
 pub struct CpuResultRow {
     pub host_id: String,
+    pub model_name: String,
     pub core_count: u32,
     pub usage_percent: f32,
+    pub per_core: Vec<f32>,
 }
 
 pub async fn fetch_latest_cpu_all(conn: &Arc<Mutex<Connection>>) -> Result<Vec<CpuResultRow>> {
     let conn = conn.lock().await;
     let mut stmt = conn.prepare(
-        "SELECT c.host_id, c.core_count, c.usage_percent \
+        "SELECT c.host_id, c.model_name, c.core_count, c.usage_percent, c.per_core_json \
          FROM cpu_results c \
          JOIN (SELECT host_id, MAX(timestamp) AS max_ts FROM cpu_results GROUP BY host_id) t \
            ON c.host_id = t.host_id AND c.timestamp = t.max_ts",
     )?;
     let rows = stmt.query_map([], |row| {
+        let per_core_json: String = row.get(4)?;
+        let per_core = serde_json::from_str(&per_core_json).unwrap_or_default();
         Ok(CpuResultRow {
             host_id: row.get::<_, String>(0)?,
-            core_count: row.get::<_, i64>(1)? as u32,
-            usage_percent: row.get::<_, f64>(2)? as f32,
+            model_name: row.get::<_, String>(1)?,
+            core_count: row.get::<_, i64>(2)? as u32,
+            usage_percent: row.get::<_, f64>(3)? as f32,
+            per_core,
         })
     })?;
-    let mut results = vec![];
+    let mut results = Vec::new();
     for r in rows {
         results.push(r?);
     }

--- a/src/tui/host_details/states.rs
+++ b/src/tui/host_details/states.rs
@@ -1,2 +1,80 @@
-#[derive(Debug, Default, Clone)]
-pub struct HostDetailsState;
+use crate::backend::db::cpu::queries as cpu_queries;
+use crate::tui::states_update::StateJob;
+use anyhow::Result;
+use rusqlite::Connection;
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::{Mutex, RwLock};
+
+#[derive(Debug, Clone, Default)]
+pub struct CpuSnapshot {
+    pub model_name: String,
+    pub core_count: u32,
+    pub usage_percent: f32,
+    pub per_core: Vec<f32>,
+}
+
+#[derive(Debug, Clone)]
+pub struct CpuStates {
+    data: Arc<RwLock<HashMap<String, CpuSnapshot>>>,
+}
+
+impl Default for CpuStates {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl CpuStates {
+    pub fn new() -> Self {
+        Self {
+            data: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+
+    pub async fn get(&self, host_id: &str) -> Option<CpuSnapshot> {
+        self.data.read().await.get(host_id).cloned()
+    }
+
+    pub async fn update_from_db(&self, conn: &Arc<Mutex<Connection>>) -> Result<()> {
+        let rows = cpu_queries::fetch_latest_cpu_all(conn).await?;
+        let mut map = self.data.write().await;
+        map.clear();
+        for row in rows {
+            map.insert(
+                row.host_id,
+                CpuSnapshot {
+                    model_name: row.model_name,
+                    core_count: row.core_count,
+                    usage_percent: row.usage_percent,
+                    per_core: row.per_core,
+                },
+            );
+        }
+        Ok(())
+    }
+
+    pub async fn snapshot_map(&self) -> HashMap<String, CpuSnapshot> {
+        self.data.read().await.clone()
+    }
+}
+
+#[derive(Clone, Debug)]
+pub enum HostDetailsJobKind {
+    Cpu(Arc<CpuStates>),
+}
+
+#[async_trait::async_trait]
+impl StateJob for HostDetailsJobKind {
+    fn name(&self) -> &'static str {
+        match self {
+            HostDetailsJobKind::Cpu(_) => "cpu",
+        }
+    }
+
+    async fn update(&self, conn: &Arc<Mutex<Connection>>) -> Result<()> {
+        match self {
+            HostDetailsJobKind::Cpu(state) => state.update_from_db(conn).await,
+        }
+    }
+}

--- a/src/tui/host_details/view.rs
+++ b/src/tui/host_details/view.rs
@@ -1,3 +1,4 @@
+use futures::executor::block_on;
 use ratatui::prelude::*;
 use ratatui::widgets::*;
 
@@ -5,14 +6,55 @@ use crate::App;
 
 pub fn render(app: &mut App, frame: &mut Frame) {
     let area = frame.size();
-    let block = Block::default().title("Host Details").borders(Borders::ALL);
-    let content = if let Some(id) = &app.selected_id {
-        format!("details view! (host: {})", id)
+    let block = Block::default().borders(Borders::ALL).title("Host Details");
+    frame.render_widget(block.clone(), area);
+
+    let inner = block.inner(area);
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3), // header
+            Constraint::Length(3), // model
+            Constraint::Length(3), // total usage
+            Constraint::Min(0),    // per cpu
+        ])
+        .split(inner);
+
+    if let Some(id) = &app.selected_id {
+        let cpu_map = block_on(app.cpu_states.snapshot_map());
+        if let Some(cpu) = cpu_map.get(id) {
+            let header = Paragraph::new(format!("CPU Usage for {}", id))
+                .alignment(Alignment::Center);
+            frame.render_widget(header, chunks[0]);
+
+            let model = Paragraph::new(cpu.model_name.clone())
+                .alignment(Alignment::Left);
+            frame.render_widget(model, chunks[1]);
+
+            let total_gauge = Gauge::default()
+                .gauge_style(Style::default().fg(Color::Green))
+                .ratio((cpu.usage_percent as f64) / 100.0)
+                .label(format!("{:.1}%", cpu.usage_percent));
+            frame.render_widget(total_gauge, chunks[2]);
+
+            let per_core_chunks = Layout::default()
+                .direction(Direction::Vertical)
+                .constraints(vec![Constraint::Length(1); cpu.per_core.len()])
+                .split(chunks[3]);
+            for (i, usage) in cpu.per_core.iter().enumerate() {
+                if i < per_core_chunks.len() {
+                    let gauge = Gauge::default()
+                        .gauge_style(Style::default().fg(Color::Cyan))
+                        .label(format!("CPU{} {:.1}%", i, usage))
+                        .ratio((*usage as f64) / 100.0);
+                    frame.render_widget(gauge, per_core_chunks[i]);
+                }
+            }
+        } else {
+            frame.render_widget(Paragraph::new("No CPU data"), inner);
+        }
     } else {
-        "details view!".to_string()
-    };
-    let paragraph = Paragraph::new(content)
-        .block(block)
-        .alignment(Alignment::Center);
-    frame.render_widget(paragraph, area);
+        frame.render_widget(Paragraph::new("No host selected"), inner);
+    }
 }

--- a/src/tui/list_ssh/states.rs
+++ b/src/tui/list_ssh/states.rs
@@ -10,8 +10,10 @@ use tokio::sync::{Mutex, RwLock};
 
 #[derive(Debug, Clone, Default)]
 pub struct CpuSnapshot {
+    pub model_name: String,
     pub core_count: u32,
     pub usage_percent: f32,
+    pub per_core: Vec<f32>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -162,8 +164,10 @@ impl CpuStates {
             map.insert(
                 row.host_id,
                 CpuSnapshot {
+                    model_name: row.model_name,
                     core_count: row.core_count,
                     usage_percent: row.usage_percent,
+                    per_core: row.per_core,
                 },
             );
         }


### PR DESCRIPTION
## Summary
- include per-core CPU data in DB queries
- keep per-core/model info in list view states
- add Host Details CPU states and job type
- show CPU usage with per-core gauges

## Testing
- `cargo test` *(fails: `cargo: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_687b2ab3046883219594b8375bd4dd1c