### PR TITLE
Implement detail view state updater

### DIFF
--- a/src/backend/db/cpu/queries.rs
+++ b/src/backend/db/cpu/queries.rs
@@ -69,3 +69,31 @@ pub async fn fetch_latest_cpu_by_host(
         Ok(None)
     }
 }
+
+pub async fn fetch_latest_cpu_detail_all(
+    conn: &Arc<Mutex<Connection>>,
+) -> Result<Vec<CpuDetailRow>> {
+    let conn = conn.lock().await;
+    let mut stmt = conn.prepare(
+        "SELECT c.host_id, c.model_name, c.core_count, c.usage_percent, c.per_core_json \
+         FROM cpu_results c \
+         JOIN (SELECT host_id, MAX(timestamp) AS max_ts FROM cpu_results GROUP BY host_id) t \
+           ON c.host_id = t.host_id AND c.timestamp = t.max_ts",
+    )?;
+    let rows = stmt.query_map([], |row| {
+        let per_core_json: String = row.get(4)?;
+        let per_core: Vec<f32> = serde_json::from_str(&per_core_json).unwrap_or_default();
+        Ok(CpuDetailRow {
+            host_id: row.get::<_, String>(0)?,
+            model_name: row.get::<_, String>(1)?,
+            core_count: row.get::<_, i64>(2)? as u32,
+            usage_percent: row.get::<_, f64>(3)? as f32,
+            per_core,
+        })
+    })?;
+    let mut results = Vec::new();
+    for r in rows {
+        results.push(r?);
+    }
+    Ok(results)
+}

--- a/src/tui/host_details/states.rs
+++ b/src/tui/host_details/states.rs
@@ -1,2 +1,93 @@
-#[derive(Debug, Default, Clone)]
-pub struct HostDetailsState;
+use crate::backend::db::cpu::queries as cpu_queries;
+use crate::tui::states_update::StateJob;
+use anyhow::Result;
+use rusqlite::Connection;
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::{Mutex, RwLock};
+
+#[derive(Debug, Clone, Default)]
+pub struct CpuDetailSnapshot {
+    pub model_name: String,
+    pub core_count: u32,
+    pub usage_percent: f32,
+    pub per_core: Vec<f32>,
+}
+
+#[derive(Debug, Clone)]
+pub struct CpuDetailStates {
+    data: Arc<RwLock<HashMap<String, CpuDetailSnapshot>>>,
+}
+
+impl Default for CpuDetailStates {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl CpuDetailStates {
+    pub fn new() -> Self {
+        Self {
+            data: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+
+    pub async fn get(&self, host_id: &str) -> Option<CpuDetailSnapshot> {
+        self.data.read().await.get(host_id).cloned()
+    }
+
+    pub async fn update_from_db(&self, conn: &Arc<Mutex<Connection>>) -> Result<()> {
+        let rows = cpu_queries::fetch_latest_cpu_detail_all(conn).await?;
+        let mut map = self.data.write().await;
+        map.clear();
+        for row in rows {
+            map.insert(
+                row.host_id,
+                CpuDetailSnapshot {
+                    model_name: row.model_name,
+                    core_count: row.core_count,
+                    usage_percent: row.usage_percent,
+                    per_core: row.per_core,
+                },
+            );
+        }
+        Ok(())
+    }
+
+    pub async fn snapshot_map(&self) -> HashMap<String, CpuDetailSnapshot> {
+        self.data.read().await.clone()
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct HostDetailsState {
+    pub cpu: Arc<CpuDetailStates>,
+}
+
+impl HostDetailsState {
+    pub fn new() -> Self {
+        Self {
+            cpu: Arc::new(CpuDetailStates::new()),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub enum DetailsJobKind {
+    Cpu(Arc<CpuDetailStates>),
+}
+
+#[async_trait::async_trait]
+impl StateJob for DetailsJobKind {
+    fn name(&self) -> &'static str {
+        match self {
+            DetailsJobKind::Cpu(_) => "cpu_detail",
+        }
+    }
+
+    async fn update(&self, conn: &Arc<Mutex<Connection>>) -> Result<()> {
+        match self {
+            DetailsJobKind::Cpu(state) => state.update_from_db(conn).await,
+        }
+    }
+}

--- a/src/tui/host_details/view.rs
+++ b/src/tui/host_details/view.rs
@@ -1,7 +1,6 @@
 use ratatui::prelude::*;
 use ratatui::widgets::*;
 
-use crate::backend::db::cpu::queries::fetch_latest_cpu_by_host;
 use futures::executor::block_on;
 
 use crate::App;
@@ -16,7 +15,7 @@ pub fn render(app: &mut App, frame: &mut Frame) {
         return;
     };
 
-    let cpu_detail = block_on(fetch_latest_cpu_by_host(&app.db, host_id)).unwrap_or(None);
+    let cpu_detail = block_on(app.details_states.cpu.get(host_id));
 
     let block = Block::default().title("CPU").borders(Borders::ALL);
     let inner_area = block.inner(area);


### PR DESCRIPTION
## Summary
- add CPU detail state management and periodic state update job
- expose DB query to fetch latest CPU details
- initialize and update detail states in the app
- use preloaded CPU details in detail view

## Testing
- `cargo fmt --all`
- `cargo check` *(fails: failed to download from crates.io)*
- `cargo test` *(fails: failed to download from crates.io)*

------
https://chatgpt.com/codex/tasks/task_e_6889653b431c83219605224b2c63343e